### PR TITLE
chore: 发布版本0.9.6，修复文件树子节点溢出问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bitcake",
   "private": true,
-  "version": "0.9.5",
+  "version": "0.9.6",
   "type": "module",
   "description": "A modern, unified web interface for Transmission and qBittorrent with PWA support",
   "scripts": {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -4847,6 +4847,9 @@ onBeforeUnmount(() => {
 .files-tree :deep(.el-tree-node__content) {
   height: 32px;
 }
+.files-tree :deep(.el-tree-node__children) {
+  overflow: visible;
+}
 .file-node {
   display: flex;
   align-items: center;


### PR DESCRIPTION
1.  更新package.json版本号至0.9.6
2.  为el-tree-node__children添加overflow: visible样式，修复文件树子节点被截断的问题

已经修复 https://github.com/wenfer/bitcake/issues/41 